### PR TITLE
[Feature] 검색기능 구현, 갤러디상세 슬라이드 설정

### DIFF
--- a/src/entity/galleryImageInput/ui/galleryImageInput.module.css
+++ b/src/entity/galleryImageInput/ui/galleryImageInput.module.css
@@ -1,5 +1,7 @@
 .container {
   display: flex;
+  height: 220px;
+  width: 100%;
 }
 
 .fileLabel {
@@ -23,10 +25,13 @@
   display: flex;
   flex-direction: column;
   gap: 5px;
+  flex-wrap: wrap;
 }
 .fileName {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 30px;
+  justify-content: flex-start;
+  gap: 20px;
+  margin-bottom: 15px;
+  margin-left: 10px;
 }

--- a/src/entity/galleryImageInput/ui/index.tsx
+++ b/src/entity/galleryImageInput/ui/index.tsx
@@ -4,6 +4,7 @@ import { Api } from "shared/api";
 import styles from "./galleryImageInput.module.css";
 import { FileType } from "shared/type/Gallery";
 import { CloseIcon } from "utils/icon";
+import confirmAlert from "shared/lib/ConfirmAlert";
 
 export type GalleryImageInputProps = {
   onUploadSuccess: (files: FileType[]) => void;
@@ -28,7 +29,7 @@ const GalleryImageInput = ({
         },
       }),
     onSuccess: (res) => {
-      const uploadFileList = res.data.data.map((file: any) => ({
+      const uploadFileList = res.data.data.map((file: FileType) => ({
         fileName: file.fileName,
         fileUrl: file.fileUrl,
       }));
@@ -58,6 +59,10 @@ const GalleryImageInput = ({
 
   const handleFileUpload = (files: FileList | null) => {
     if (files) {
+      if (uploadFiles.length + files.length > 10) {
+        confirmAlert("warning", "최대 10개의 파일만 업로드할 수 있습니다.");
+        return;
+      }
       const formData = new FormData();
       Array.from(files).forEach((file) => {
         formData.append("uploadFiles", file);

--- a/src/entity/galleryImageInput/ui/index.tsx
+++ b/src/entity/galleryImageInput/ui/index.tsx
@@ -59,8 +59,8 @@ const GalleryImageInput = ({
 
   const handleFileUpload = (files: FileList | null) => {
     if (files) {
-      if (uploadFiles.length + files.length > 10) {
-        confirmAlert("warning", "최대 10개의 파일만 업로드할 수 있습니다.");
+      if (uploadFiles.length + files.length > 20) {
+        confirmAlert("warning", "최대 20개의 파일만 업로드할 수 있습니다.");
         return;
       }
       const formData = new FormData();

--- a/src/features/galleryDetailModal/ui/galleryDetail.module.css
+++ b/src/features/galleryDetailModal/ui/galleryDetail.module.css
@@ -31,23 +31,36 @@
 
 .detailImageListWrapper {
   width: 100%;
+  min-width: 300px;
   display: flex;
-  justify-content: center;
   flex-direction: row;
   gap: 5px;
+  overflow-x: scroll;
 }
 
 .detailImage,
 .selectedImage {
-  width: 190px;
+  width: 150px;
   height: 140px;
 }
 
 .centerImage {
   width: 85%;
   height: 520px;
+  max-width: 900px;
 }
 
 .selectedImage {
-  border: 4px solid orange;
+  border: 4px solid var(--primary-color);
+}
+
+.detailImageListWrapper::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.detailImageListWrapper::-webkit-scrollbar-thumb {
+  background: var(--primary-color);
+  border: 2px solid #9b6a2f;
+  border-radius: 12px 12px 12px 12px;
 }

--- a/src/pages/galleryPage/ui/galleryPage.module.css
+++ b/src/pages/galleryPage/ui/galleryPage.module.css
@@ -3,7 +3,8 @@
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  gap: 50px;
+  gap: 20px;
+  padding-bottom: 50px;
 }
 
 .GalleryPageHeader {
@@ -11,7 +12,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 100px;
+  padding-top: 30px;
 }
 
 .GalleryPageHeader > h1 {

--- a/src/pages/galleryPage/ui/index.tsx
+++ b/src/pages/galleryPage/ui/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import GalleryCardList from "entity/galleryCardList/ui";
 import styles from "./galleryPage.module.css";
 import { Pagination } from "widgets/pagination";
@@ -13,28 +13,62 @@ const GalleryPage = () => {
   const [page, setPage] = useState(1);
   const [searchCategory, setSearchCategory] = useState("제목");
   const [searchKeyword, setSearchKeyword] = useState("");
+  const [filteredGalleries, setFilteredGalleries] = useState<GalleryCardType[]>(
+    []
+  );
 
-  const handleSearch = () => {
-    setPage(1);
-    refetch();
-  };
-
+  // 페이지 전체 조회하는 쿼리
   const { data: galleryData, refetch } = useQuery({
-    queryKey: ["galleries", page, searchCategory, searchKeyword],
+    queryKey: ["galleries", page],
     queryFn: () =>
       Api.get(`/v1/api/gallery`, {
         params: {
           page: page - 1,
           size: 6,
           official: true,
-          searchCategory,
-          searchKeyword,
         },
       }),
   });
+
   const galleries: GalleryCardType[] = galleryData?.data.data.galleries ?? [];
   const totalPage: number = galleryData?.data.data.totalPages ?? 0;
 
+  // 검색 결과 필터링 및 페이지 이동
+  useEffect(() => {
+    if (!galleryData) return;
+    const filterGalleries = () => {
+      return galleries.filter((gallery) =>
+        //galleries 데이터를 필터해서
+        searchCategory === "제목" || searchCategory === "전체"
+          ? //제목이나 전체로 검색했을 때 true면 타이틀을 포함하는 갤러리만 반환
+            gallery.title?.includes(searchKeyword) ?? false
+          : true
+      );
+    };
+    setFilteredGalleries(filterGalleries());
+    //검색어가 바뀌면 필터링된 갤러리를 다시 세팅
+  }, [galleryData, searchCategory]);
+
+  // 검색 결과 페이지로 이동하는 함수 호출
+  const findTargetPage = () => {
+    Api.get(`/v1/api/gallery`, {
+      params: {
+        page: 0,
+        size: totalPage * 6,
+        official: true,
+      },
+    }).then((res) => {
+      const allGalleries = res.data.data.galleries;
+      const foundIndex = allGalleries.findIndex((gallery: GalleryCardType) =>
+        gallery.title?.includes(searchKeyword)
+      );
+      const targetPageNumber =
+        foundIndex !== -1 ? Math.floor(foundIndex / 6) + 1 : 1;
+      setPage(targetPageNumber);
+      refetch();
+    });
+  };
+  //refetch를 사용하면 바로바로 바뀜 -> 검색은 한번 눌러야함
   return (
     <div className={styles.container}>
       <div className={styles.GalleryPageHeader}>
@@ -43,13 +77,13 @@ const GalleryPage = () => {
           <RegitUpdateDeleteButton content="등록하기" />
         </Link>
       </div>
-      <GalleryCardList galleries={galleries} />
+      <GalleryCardList galleries={filteredGalleries} />
       <Pagination totalPages={totalPage} page={page} setPage={setPage} />
       <SearchBar
         searchCategory={searchCategory}
         setSearchCategory={setSearchCategory}
         setSearchKeyword={setSearchKeyword}
-        handleSearch={handleSearch}
+        handleSearch={() => findTargetPage()}
       />
     </div>
   );

--- a/src/pages/galleryPage/ui/index.tsx
+++ b/src/pages/galleryPage/ui/index.tsx
@@ -68,7 +68,6 @@ const GalleryPage = () => {
       refetch();
     });
   };
-  console.log('필터')
   //refetch를 사용하면 바로바로 바뀜 -> 검색은 한번 눌러야함
   return (
     <div className={styles.container}>

--- a/src/pages/galleryPage/ui/index.tsx
+++ b/src/pages/galleryPage/ui/index.tsx
@@ -68,6 +68,7 @@ const GalleryPage = () => {
       refetch();
     });
   };
+  console.log('필터')
   //refetch를 사용하면 바로바로 바뀜 -> 검색은 한번 눌러야함
   return (
     <div className={styles.container}>

--- a/src/pages/galleryPage/ui/index.tsx
+++ b/src/pages/galleryPage/ui/index.tsx
@@ -46,8 +46,9 @@ const GalleryPage = () => {
       );
     };
     setFilteredGalleries(filterGalleries());
+
     //검색어가 바뀌면 필터링된 갤러리를 다시 세팅
-  }, [galleryData, searchCategory]);
+  }, [galleryData, searchCategory, searchKeyword]);
 
   // 검색 결과 페이지로 이동하는 함수 호출
   const findTargetPage = () => {
@@ -65,10 +66,9 @@ const GalleryPage = () => {
       const targetPageNumber =
         foundIndex !== -1 ? Math.floor(foundIndex / 6) + 1 : 1;
       setPage(targetPageNumber);
-      refetch();
     });
   };
-  //refetch를 사용하면 바로바로 바뀜 -> 검색은 한번 눌러야함
+
   return (
     <div className={styles.container}>
       <div className={styles.GalleryPageHeader}>

--- a/src/shared/ui/commonModal/index.tsx
+++ b/src/shared/ui/commonModal/index.tsx
@@ -27,6 +27,7 @@ const CommnModal = ({
   onRequestClose,
   style,
 }: ModalProps) => {
+  //모달창 나왔을 때 body 스크롤 막기
   useEffect(() => {
     if (isopen) {
       document.body.style.overflow = "hidden";


### PR DESCRIPTION
### #️⃣연관된 이슈
- ex) #이슈번호, #이슈번호
- #40 
### 📝작업 내용
- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 검색 구현
- 갤러리 디테일에서 이미지 많을 때 슬라이드로 보이도록 (하단쪽)
- 이미지 업로드시 최대 20개로 제한해놨습니다. 
### 스크린샷 (선택)
![스크린샷 2024-06-05 230110](https://github.com/JBA-jeju-basketball-association/JBA-FE/assets/133099388/dfeac613-0e39-456f-9701-23836a31af08)
![스크린샷 2024-06-05 174834](https://github.com/JBA-jeju-basketball-association/JBA-FE/assets/133099388/32e013ac-b0a6-4549-a0ed-8290bfbf5ca7)
![스크린샷 2024-06-05 234349](https://github.com/JBA-jeju-basketball-association/JBA-FE/assets/133099388/48897dd5-8668-441f-8521-9873a1e2e530)


### 💬리뷰 요구사항(선택)
- 검색기능도 url의 쿼리파람을 통해서 조회하나요?? 아니면 클라이언트에서 찾아서 적용하나요? 일단은 response의 title을 기반으로 만들었는데 잘 모르겠어서 여쭤봅니다!
- 검색이 useEffect 디펜던시에 searchKeyword를 넣어서 그런지 화면이 바뀌긴 하는데 엔터를 쳐야 해당 게시물이 있는 페이지로 넘어가네요, 좀 애매한 구현..ㅜㅜ 검색 어려워요..
- 이제 게시물 수정이랑 삭제만 남은 것 같습니다. 일단 수정이랑 삭제는 예비로 갤러리 제목에 미트볼 버튼 넣어서 만들어놓을까 합니다.
