### PR TITLE
[QA] 페이지 이동시 검색바 상태 초기화

### DIFF
--- a/src/pages/postPage/ui/PostListPage.tsx
+++ b/src/pages/postPage/ui/PostListPage.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { PostListTable } from "../../../entities/postListTable";
 import { Pagination } from "widgets/pagination";
 import {
   useQuery,
-  useQueryClient,
   keepPreviousData,
+  useQueryClient,
 } from "@tanstack/react-query";
 import { NormalApi } from "../../../shared/api";
 import { PostListData } from "../../../shared/type/PostType";
@@ -18,10 +18,12 @@ import {
 } from "../../../shared/ui";
 import { JwtDecoder } from "../../../shared/lib";
 import { useUserStore } from "../../../shared/model";
+import confirmAlert from "shared/lib/ConfirmAlert";
 
 export const PostListPage = () => {
   const [page, setPage] = useState<number>(1);
-  const [searchKeyword, setSearchKeyword] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState<string>("");
+  const [searchInput, setSearchInput] = useState<string>("");
   let { category } = useParams();
   const navigate = useNavigate();
   const { AccessToken } = useUserStore();
@@ -37,34 +39,36 @@ export const PostListPage = () => {
     isLoading,
     isError,
     data: postList,
-    refetch,
   } = useQuery<PostListData>({
-    queryKey: ["postList", `${category}`, `${page}`],
+    queryKey: ["postList", category, page, searchInput],
     queryFn: () =>
       NormalApi.get(
-        `/v1/api/post/${category}?page=${page - 1}&size=10&keyword=${searchKeyword}`
+        `/v1/api/post/${category}?page=${page - 1}&size=10&keyword=${searchInput}`
       ),
     select: (result: any) => result.data.data,
     placeholderData: keepPreviousData,
   });
 
   const findTargetPage = () => {
-    if (searchKeyword.length >= 2) {
+    if (searchKeyword.length >= 2 || searchKeyword.length === 0) {
       setPage(1);
-      refetch();
-    } else if (searchKeyword.length === 0) {
-      setPage(1);
-      refetch();
-    } 
-    else {
-      alert("🔎 검색어는 두 글자 이상 입력해주세요!");
+      setSearchInput(searchKeyword);
+    } else {
+      alert("🔎 검색은 두 글자 이상 해주세요");
+      setSearchInput('');
+      setSearchKeyword('');
     }
   };
-  // const queryClient = useQueryClient();
 
   // useEffect(() => {
-  //   queryClient.invalidateQueries({ queryKey: ["postList"] });
+  //   queryClient.invalidateQueries({ queryKey: ['postList'] });
   // }, [searchKeyword]);
+
+  // 검색 -> 키워드 업데이트 -> 엔터 이벤트 -> 서치인풋상태 업데이트 -> 메뉴바 클릭 -> 검색 키워드 초기화 -> 페이지 목록 리패치
+  useEffect(() => {
+    setSearchInput("");
+    setSearchKeyword("");
+  }, [category]);
 
   if (isError) {
     return <span>Error</span>;
@@ -88,7 +92,7 @@ export const PostListPage = () => {
           <SearchBar
             searchKeyword={searchKeyword}
             setSearchKeyword={setSearchKeyword}
-            handleSearch={() => findTargetPage()}
+            handleSearch={findTargetPage}
           />
         </div>
         {isLoading && <LoadingSpinner />}

--- a/src/widgets/searchBar/ui/SearchBar.tsx
+++ b/src/widgets/searchBar/ui/SearchBar.tsx
@@ -5,7 +5,7 @@ import { FaSearch } from "react-icons/fa";
 type Props = {
   searchKeyword?: string;
   setSearchKeyword: React.Dispatch<React.SetStateAction<string>>;
-  handleSearch: any;
+  handleSearch: () => void;
 };
 
 export const SearchBar = ({
@@ -30,7 +30,7 @@ export const SearchBar = ({
     setTypeingTimeOut(
       setTimeout(() => {
         setSearchKeyword(value);
-        handleSearch();
+        // handleSearch();
       }, 500)
     );
   };
@@ -46,6 +46,7 @@ export const SearchBar = ({
         placeholder={"검색"}
         maxLength={20}
         minLength={2}
+        value={searchKeyword}
       />
       <FaSearch
         size={"20"}


### PR DESCRIPTION
### #️⃣연관된 이슈
#115 

### 📝작업 내용
### 게시글 리스트 페이지 이동시 검색바 value 초기화
**원인**

검색 키워드를 상태로 관리해주고 있었다.

인풋의 onChange 이벤트가 일어나면 검색 키워드를 업데이트 해준다.

키워드가 업데이트 되어있는 상태에서 메뉴바를 클릭하면 키워드를 활용해 쿼리 스트링으로 게시글 목록을 불러온다.

그래서 useEffect를 활용해 [카테고리]가 변경되면 setKeyWord 해주었다.

검색바의 값은 잘 초기화돼서 출력되지만 setKeyWord(" ") 해준 값을 이용해 목록을 불러오고 있지 않고 이 전의 keyWord를 통해 게시글이 출력된다.

useEffect로 [keyWord]를 활용해 게시글 목록을 불러와주고 싶었지만 input의 onChange 이벤트가 일어날때 계속 패치해온다는 문제 + 검색이 두글자 이상이 아니면 서버에서 에러를 보내준다는 것(한글자 입력하면 바로 패치요청이가고 에러가 날라옴)

**해결**

상태를 두개로 나눠서 관리해줌

searchKeyword(인풋이 onChange될때마다 최신으로 업데이트: 검색 키워드 상태 관리 + 화면 출력),

searchInput(키 다운 이벤트 발생 시 setSearchInput(searchKeyword) -> 데이터를 패치해올때 쿼리스트링 값으로 쓰임)

useEffect [카테고리]가 바뀌면 searchKeyword, searchInput 모두 초기화

queryKey에 [searchInput] 등록 -> setSearchInput(searchKeyword) -> 리패치

키 다운 이벤트 발생 -> handleSearch() -> findTarget() -> keyword.length 두 글자 || 0 글자 이면 setInputKeyword 아니면 setSearchInput(''), setSearchKeyword('')

### 스크린샷 (선택)


### 💬리뷰 요구사항(선택)
⭐️ ckEditor 보고 있는데 alignment 기능이 적용이 안돼서 삽질중 ... 
