### PR TITLE
[FIX] 관리자 게시물 페이지 등록 버튼 추가 및 다른 수정

### DIFF
--- a/src/features/admin/ui/AdminCompetitionListData.tsx
+++ b/src/features/admin/ui/AdminCompetitionListData.tsx
@@ -5,7 +5,6 @@ import {
   AdminCompetitionListProps,
   CompetitionListsType,
 } from "shared/type/AdminType";
-import { useFileDownload } from "shared/hook/useFileDownload";
 import { useTruncateString } from "shared/hook/useTruncateString";
 import confirmAndCancelAlertWithLoading from "shared/lib/ConfirmAndCancelAlertWithLoading";
 import { useAdminCompetitionDelete } from "pages/admin/api/useAdminCompetitionDatas";
@@ -26,7 +25,6 @@ export const AdminCompetitionListData = ({
 
   const deleteT = (date: string | null) => date?.replace("T", " ");
 
-  const { fileDownload } = useFileDownload();
   const { mutate: competitionDelete } = useAdminCompetitionDelete();
 
   const truncateString = useTruncateString();
@@ -168,12 +166,8 @@ export const AdminCompetitionListData = ({
                 ? list.files.map((file, index) => (
                     <a
                       key={index}
-                      // href={file.filePath}
-                      // download={file.fileName}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        fileDownload(file.filePath, file.fileName);
-                      }}
+                      href={file.filePath}
+                      download={file.fileName}
                       rel="noreferrer"
                     >
                       {truncateString(file.fileName, 10)}

--- a/src/features/admin/ui/AdminCompetitionListData.tsx
+++ b/src/features/admin/ui/AdminCompetitionListData.tsx
@@ -56,7 +56,7 @@ export const AdminCompetitionListData = ({
         return window.open(`/competition/post/schedule/${competitionId}`);
 
       case "SCHEDULE":
-        return window.open(`/competition/post/schedule/${competitionId}`);
+        return window.open(`/competition/post/result/${competitionId}`);
 
       default:
         return "";
@@ -130,7 +130,7 @@ export const AdminCompetitionListData = ({
                     handleNavigateToResultUpload(list.competitionId, list.phase)
                   }
                 >
-                  대회일정 수정
+                  대회일정 등록
                 </Button>
               )}
               {list.phase === "SCHEDULE" && (
@@ -140,7 +140,7 @@ export const AdminCompetitionListData = ({
                     handleNavigateToResultUpload(list.competitionId, list.phase)
                   }
                 >
-                  대회결과 수정
+                  대회결과 등록
                 </Button>
               )}
             </span>

--- a/src/features/admin/ui/AdminPostListData.tsx
+++ b/src/features/admin/ui/AdminPostListData.tsx
@@ -6,7 +6,6 @@ import {
   useAdminPostDelete,
   useAdminchangeAnnouncement,
 } from "pages/admin/api/useAdminPostDatas";
-import { useFileDownload } from "shared/hook/useFileDownload";
 import confirmAndCancelAlertWithLoading from "shared/lib/ConfirmAndCancelAlertWithLoading";
 import { useTruncateString } from "shared/hook/useTruncateString";
 
@@ -59,9 +58,6 @@ export const AdminPostListData = ({ titles, lists }: AdminPostListProps) => {
     );
   };
   //공지로 변경-해제
-
-  const { fileDownload } = useFileDownload();
-  //파일 다운로드 함수
 
   return (
     <div className={styles.container}>
@@ -117,10 +113,8 @@ export const AdminPostListData = ({ titles, lists }: AdminPostListProps) => {
                 ? list.files.map((file, index) => (
                     <a
                       key={index}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        fileDownload(file.fileUrl, file.fileName);
-                      }}
+                      href={file.fileUrl}
+                      download={file.fileName}
                       rel="noreferrer"
                     >
                       {truncateString(file.fileName, 10)}

--- a/src/features/admin/ui/AdminUserListData.tsx
+++ b/src/features/admin/ui/AdminUserListData.tsx
@@ -9,16 +9,14 @@ import { userPermissionMap } from "pages/admin/adminUtils/adminUserTitle";
 export const AdminUserListData = ({ titles, lists }: AdminUserListProps) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [selectUser, setSelectUser] = useState<UserListsType | null>(null);
-  const gender = (gender: string) => (gender === "mail" ? "남자" : "여자");
+
+  const gender = (gender: string) => (gender === "male" ? "남자" : "여자");
+
   const permissions = (permission: string) => {
     const findPermission = userPermissionMap.find(
       (user) => user.value === permission
     );
     return findPermission?.label || "없음";
-  };
-
-  const formatDate = (isoDate: any) => {
-    return isoDate.split("T")[0];
   };
 
   const userStatus = (status: string) => {

--- a/src/pages/admin/api/useAdminCompetitionDatas.ts
+++ b/src/pages/admin/api/useAdminCompetitionDatas.ts
@@ -3,7 +3,7 @@ import { Api } from "shared/api";
 import confirmAlert from "shared/lib/ConfirmAlert";
 import { useFormattedDate } from "shared/hook/useFormattedDate";
 
-type useAdminCompetitionDatas = {
+type useAdminCompetitionDataProps = {
   page: number;
   competitionListLength: any;
   firstCategory?: any;
@@ -16,7 +16,7 @@ type useAdminCompetitionDatas = {
 };
 
 export const useAdminCompetitionDatas = (
-  params: useAdminCompetitionDatas,
+  params: useAdminCompetitionDataProps,
   enabled: boolean
 ) => {
   const firCategoryKeyMap: { [key: string]: string | null } = {
@@ -47,6 +47,7 @@ export const useAdminCompetitionDatas = (
         },
       }),
     enabled,
+    select: (res: any) => res.data.data,
   });
 };
 

--- a/src/pages/admin/api/useAdminGalleryDatas.ts
+++ b/src/pages/admin/api/useAdminGalleryDatas.ts
@@ -49,6 +49,7 @@ export const useAdminGalleryDatas = (
         },
       }),
     enabled,
+    select: (res: any) => res.data.data,
   });
 };
 

--- a/src/pages/admin/api/useAdminPostDatas.ts
+++ b/src/pages/admin/api/useAdminPostDatas.ts
@@ -54,6 +54,7 @@ export const useAdminPostDatas = (
         },
       }),
     enabled,
+    select: (res: any) => res.data.data,
   });
 };
 

--- a/src/pages/admin/api/useAdminUserDatas.ts
+++ b/src/pages/admin/api/useAdminUserDatas.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Api } from "shared/api";
 import confirmAlert from "shared/lib/ConfirmAlert";
@@ -58,6 +57,7 @@ export const useAdminUserDatas = (
         },
       }),
     enabled,
+    select: (res: any) => res.data.data,
   });
 };
 

--- a/src/pages/admin/ui/AdminCompetition.tsx
+++ b/src/pages/admin/ui/AdminCompetition.tsx
@@ -20,6 +20,7 @@ import {
 import { AdminSearchForm } from "features/admin";
 import { SituationBtn } from "features/admin";
 import { CSVLink } from "react-csv";
+import confirmAlert from "shared/lib/ConfirmAlert";
 
 export const AdminCompetition = () => {
   const [isEnabled, setIsEnabled] = useState(false);
@@ -72,6 +73,10 @@ export const AdminCompetition = () => {
   };
 
   const handleSearch = () => {
+    if (totalPage.totalElements === 0) {
+      confirmAlert("info", "조회 가능한 데이터가 없습니다.");
+      return;
+    }
     setIsEnabled(true);
     refetch();
   };
@@ -137,7 +142,7 @@ export const AdminCompetition = () => {
             >
               대회 등록
             </Button>
-            {competitionCsvData && (
+            {adminCompetitionData.content && (
               <CSVLink
                 headers={competitionCsv}
                 data={competitionCsvData}

--- a/src/pages/admin/ui/AdminCompetition.tsx
+++ b/src/pages/admin/ui/AdminCompetition.tsx
@@ -60,20 +60,12 @@ export const AdminCompetition = () => {
 
   const { data: competitionCsvDatas } = useAdminCompetitionCsv(isEnabled);
 
-  const adminCompetitionData = adminCompetitionDatas?.data.data ?? [];
-  //대회 상세 데이터
-  const totalPage = adminCompetitionDatas?.data.data ?? 0;
-  //대회 데이터 총 페이지
-
-  const csvData = competitionCsvDatas?.data.data.content ?? [];
-  //csv데이터 Size100000
-
   const handleNavigateToUploadPage = () => {
     window.open("/competition/post");
   };
 
   const handleSearch = () => {
-    if (totalPage.totalElements === 0) {
+    if (adminCompetitionDatas?.totalElements === 0) {
       confirmAlert("info", "조회 가능한 데이터가 없습니다.");
       return;
     }
@@ -91,6 +83,8 @@ export const AdminCompetition = () => {
     refetch();
   };
 
+  const csvData = competitionCsvDatas?.data.data.content ?? [];
+  
   const flattenCompetition = (content: any) => {
     return content?.map((data: any) => ({
       ...data,
@@ -125,7 +119,7 @@ export const AdminCompetition = () => {
         <SituationBtn setSelectSituation={setSelectSituation} />
         <div className={styles.listLengthBox}>
           <div className={styles.listLength}>
-            총 {totalPage.totalElements || "0"}건
+            총 {adminCompetitionDatas?.totalElements || "0"}건
             <div className={styles.CategoryListWrapper}>
               <CategoryList
                 categories={competitionListLength}
@@ -142,7 +136,7 @@ export const AdminCompetition = () => {
             >
               대회 등록
             </Button>
-            {adminCompetitionData.content && (
+            {adminCompetitionDatas?.content && (
               <CSVLink
                 headers={competitionCsv}
                 data={competitionCsvData}
@@ -156,10 +150,10 @@ export const AdminCompetition = () => {
         </div>
         <AdminCompetitionListData
           titles={competitionListTitles}
-          lists={adminCompetitionData.content}
+          lists={adminCompetitionDatas?.content}
         />
         <Pagination
-          totalPages={totalPage.totalPages}
+          totalPages={adminCompetitionDatas?.totalPages}
           page={page}
           setPage={setPage}
         />

--- a/src/pages/admin/ui/AdminGallery.tsx
+++ b/src/pages/admin/ui/AdminGallery.tsx
@@ -59,16 +59,12 @@ export const AdminGallery = () => {
 
   const { data: galleryCsvDatas } = useAdminGalleryCsv(isEnabled);
 
-  const adminGalleryData = adminGalleryDatas?.data.data ?? [];
-  const totalPage: number = adminGalleryDatas?.data.data.totalPages ?? 0;
-  const csvData = galleryCsvDatas?.data.data.galleries ?? [];
-
   const handleNavigateToUploadPage = () => {
     window.open("/admin/galleryupload");
   };
 
   const handleSearch = () => {
-    if (adminGalleryData.totalGalleries === 0) {
+    if (adminGalleryDatas?.totalGalleries === 0) {
       confirmAlert("info", "조회 가능한 데이터가 없습니다.");
       return;
     }
@@ -85,6 +81,7 @@ export const AdminGallery = () => {
     setIsEnabled(false);
     refetch();
   };
+  const csvData = galleryCsvDatas?.data.data.galleries ?? [];
 
   const galleryCsvData = flattenDatas(csvData);
 
@@ -112,7 +109,7 @@ export const AdminGallery = () => {
       <div className={styles.listWrapper}>
         <div className={styles.listLengthBox}>
           <div className={styles.listLength}>
-            총 {adminGalleryData.totalGalleries || "0"}건
+            총 {adminGalleryDatas?.totalGalleries || "0"}건
             <div className={styles.CategoryListWrapper}>
               <CategoryList
                 categories={galleryListLength}
@@ -129,7 +126,7 @@ export const AdminGallery = () => {
             >
               미디어 등록
             </Button>
-            {adminGalleryData.galleries && (
+            {adminGalleryDatas?.galleries && (
               <CSVLink
                 headers={galleryCsv}
                 data={galleryCsvData}
@@ -143,9 +140,13 @@ export const AdminGallery = () => {
         </div>
         <AdminGalleryListData
           titles={galleryListTitles}
-          lists={adminGalleryData.galleries}
+          lists={adminGalleryDatas?.galleries}
         />
-        <Pagination totalPages={totalPage} page={page} setPage={setPage} />
+        <Pagination
+          totalPages={adminGalleryDatas?.totalPages}
+          page={page}
+          setPage={setPage}
+        />
       </div>
     </div>
   );

--- a/src/pages/admin/ui/AdminGallery.tsx
+++ b/src/pages/admin/ui/AdminGallery.tsx
@@ -20,6 +20,7 @@ import Button from "shared/ui/button";
 import { useAdminGalleryStore } from "shared/model/stores/AdminGalleryStore";
 import { CSVLink } from "react-csv";
 import { useFlattenData } from "shared/hook/useFlattenData";
+import confirmAlert from "shared/lib/ConfirmAlert";
 
 export const AdminGallery = () => {
   //몇개씩 조회할건지 내려주는 state
@@ -67,6 +68,10 @@ export const AdminGallery = () => {
   };
 
   const handleSearch = () => {
+    if (adminGalleryData.totalGalleries === 0) {
+      confirmAlert("info", "조회 가능한 데이터가 없습니다.");
+      return;
+    }
     setIsEnabled(true);
     refetch();
   };
@@ -124,7 +129,7 @@ export const AdminGallery = () => {
             >
               미디어 등록
             </Button>
-            {galleryCsvData && (
+            {adminGalleryData.galleries && (
               <CSVLink
                 headers={galleryCsv}
                 data={galleryCsvData}

--- a/src/pages/admin/ui/AdminPost.tsx
+++ b/src/pages/admin/ui/AdminPost.tsx
@@ -56,23 +56,20 @@ export const AdminPost = () => {
   const { data: postCsvDatas } = useAdminPostCsv(isEnabled);
   //csv데이터 size100000
 
-  const adminPostData = adminPostDatas?.data.data ?? [];
-  const totalPage: number = adminPostDatas?.data.data.totalPages ?? 0;
-  const csvData = postCsvDatas?.data.data.posts ?? [];
-
+  
   const uploadPage = (categroy: string) => {
     window.open(`/post/${categroy}/add`);
   };
-
+  
   const handleSearch = () => {
-    if (adminPostData.totalPosts === 0) {
+    if (adminPostDatas?.totalPosts === 0) {
       confirmAlert("info", "조회 가능한 데이터가 없습니다.");
       return;
     }
     setIsEnabled(true);
     refetch();
   };
-
+  
   const handleReset = () => {
     setSelectedfirstCategory(firPostcategory[0]);
     setSelectedSecondCategory(secPostcategory[0]);
@@ -81,7 +78,8 @@ export const AdminPost = () => {
     setEndDate(null);
     setIsEnabled(false);
   };
-
+  
+  const csvData = postCsvDatas?.data.data.posts ?? [];
   // 평탄화된 데이터
   const postCsvData = flattenDatas(csvData);
 
@@ -109,7 +107,7 @@ export const AdminPost = () => {
       <div className={styles.listWrapper}>
         <div className={styles.listLengthBox}>
           <div className={styles.listLength}>
-            총 {adminPostData.totalPosts || "0"}건
+            총 {adminPostDatas?.totalPosts || "0"}건
             <div className={styles.CategoryListWrapper}>
               <CategoryList
                 categories={postListLength}
@@ -138,7 +136,7 @@ export const AdminPost = () => {
             >
               자료실 등록
             </Button>
-            {adminPostData.posts && (
+            {adminPostDatas?.posts && (
               <CSVLink
                 headers={postCsv}
                 data={postCsvData}
@@ -152,9 +150,13 @@ export const AdminPost = () => {
         </div>
         <AdminPostListData
           titles={postListTitles}
-          lists={adminPostData.posts}
+          lists={adminPostDatas?.posts}
         />
-        <Pagination totalPages={totalPage} page={page} setPage={setPage} />
+        <Pagination
+          totalPages={adminPostDatas?.totalPages}
+          page={page}
+          setPage={setPage}
+        />
       </div>
     </div>
   );

--- a/src/pages/admin/ui/AdminPost.tsx
+++ b/src/pages/admin/ui/AdminPost.tsx
@@ -17,6 +17,7 @@ import Button from "shared/ui/button";
 import { useAdminPostStore } from "shared/model/stores/AdminPostStore";
 import { CSVLink } from "react-csv";
 import { useFlattenData } from "shared/hook/useFlattenData";
+import confirmAlert from "shared/lib/ConfirmAlert";
 
 export const AdminPost = () => {
   const [isEnabled, setIsEnabled] = useState(false);
@@ -59,11 +60,15 @@ export const AdminPost = () => {
   const totalPage: number = adminPostDatas?.data.data.totalPages ?? 0;
   const csvData = postCsvDatas?.data.data.posts ?? [];
 
-  const handleNavigateToUploadPage = () => {
-    window.open("/post/notice/add");
+  const uploadPage = (categroy: string) => {
+    window.open(`/post/${categroy}/add`);
   };
 
   const handleSearch = () => {
+    if (adminPostData.totalPosts === 0) {
+      confirmAlert("info", "조회 가능한 데이터가 없습니다.");
+      return;
+    }
     setIsEnabled(true);
     refetch();
   };
@@ -117,15 +122,27 @@ export const AdminPost = () => {
           <div>
             <Button
               className={styles.uploadBtn}
-              onClick={handleNavigateToUploadPage}
+              onClick={() => uploadPage("notice")}
             >
-              게시물 등록
+              공지 등록
             </Button>
-            {postCsvData && (
+            <Button
+              className={styles.uploadBtn}
+              onClick={() => uploadPage("news")}
+            >
+              news 등록
+            </Button>
+            <Button
+              className={styles.uploadBtn}
+              onClick={() => uploadPage("library")}
+            >
+              자료실 등록
+            </Button>
+            {adminPostData.posts && (
               <CSVLink
                 headers={postCsv}
                 data={postCsvData}
-                filename="posts.csv"
+                filename="post.csv"
                 className={styles.csvBtn}
               >
                 엑셀 다운로드
@@ -142,5 +159,3 @@ export const AdminPost = () => {
     </div>
   );
 };
-
-

--- a/src/pages/admin/ui/AdminUser.tsx
+++ b/src/pages/admin/ui/AdminUser.tsx
@@ -15,6 +15,7 @@ import { useAdminUserDatas, useAdminUserCsv } from "../api/useAdminUserDatas";
 import { useAdminUserStore } from "shared/model/stores/AdminUserStore";
 import { AdminSearchForm } from "features/admin";
 import { CSVLink } from "react-csv";
+import confirmAlert from "shared/lib/ConfirmAlert";
 
 export const AdminUser = () => {
   const [isEnabled, setIsEnabled] = useState(false);
@@ -57,6 +58,10 @@ export const AdminUser = () => {
   const csvData = userCsvDatas?.data.data.content ?? [];
 
   const handleSearch = () => {
+    if (adminUserData.totalElements === 0) {
+      confirmAlert("info", "조회 가능한 데이터가 없습니다.");
+      return;
+    }
     setIsEnabled(true);
     refetch();
   };

--- a/src/pages/admin/ui/AdminUser.tsx
+++ b/src/pages/admin/ui/AdminUser.tsx
@@ -53,12 +53,8 @@ export const AdminUser = () => {
 
   const { data: userCsvDatas } = useAdminUserCsv(isEnabled);
 
-  const adminUserData = adminUserDatas?.data.data ?? [];
-  const totalPage = adminUserDatas?.data.data.totalPages ?? 0;
-  const csvData = userCsvDatas?.data.data.content ?? [];
-
   const handleSearch = () => {
-    if (adminUserData.totalElements === 0) {
+    if (adminUserDatas?.totalElements === 0) {
       confirmAlert("info", "조회 가능한 데이터가 없습니다.");
       return;
     }
@@ -74,6 +70,7 @@ export const AdminUser = () => {
     setEndDate(null);
     setIsEnabled(false);
   };
+  const csvData = userCsvDatas?.data.data.content ?? [];
 
   return (
     <div className={styles.container}>
@@ -99,7 +96,7 @@ export const AdminUser = () => {
       <div className={styles.listWrapper}>
         <div className={styles.listLengthBox}>
           <div className={styles.listLength}>
-            총 {adminUserData.totalElements || "0"}건
+            총 {adminUserDatas?.totalElements || "0"}건
             <div className={styles.CategoryListWrapper}>
               <CategoryList
                 categories={userListLength}
@@ -110,7 +107,7 @@ export const AdminUser = () => {
             개씩 보기
           </div>
           <div>
-            {adminUserData.content && (
+            {adminUserDatas?.content && (
               <CSVLink
                 headers={userCsv}
                 data={csvData}
@@ -124,9 +121,13 @@ export const AdminUser = () => {
         </div>
         <AdminUserListData
           titles={userListTitles}
-          lists={adminUserData.content}
+          lists={adminUserDatas?.content}
         />
-        <Pagination totalPages={totalPage} page={page} setPage={setPage} />
+        <Pagination
+          totalPages={adminUserDatas?.totalPages}
+          page={page}
+          setPage={setPage}
+        />
       </div>
     </div>
   );

--- a/src/pages/galleryPages/api/useGalleryEdit.ts
+++ b/src/pages/galleryPages/api/useGalleryEdit.ts
@@ -13,10 +13,11 @@ export const useGalleryEdit = (galleryId: number) => {
       Api.put(`/v1/api/gallery/${galleryId}`, data),
     onSuccess: () => {
       confirmAlert("success", "수정이 완료되었습니다.");
-      navigate('/admin/gallery');
+      navigate("/gallery");
       queryClient.invalidateQueries({
         queryKey: ["galleryDetail"],
       });
+      queryClient.invalidateQueries({ queryKey: ["adminGallery"] });
     },
     onError: (e) => {
       console.log(e, "error");

--- a/src/pages/galleryPages/api/useGalleryUpload.ts
+++ b/src/pages/galleryPages/api/useGalleryUpload.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Api } from "shared/api";
 import { useNavigate } from "react-router-dom";
 import confirmAlert from "shared/lib/ConfirmAlert";
@@ -6,6 +6,7 @@ import { UploadType } from "shared/type/GalleryType";
 
 export const useGalleryUpload = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationKey: ["galleryUpload"],
     mutationFn: (data: UploadType) =>
@@ -16,7 +17,8 @@ export const useGalleryUpload = () => {
       }),
     onSuccess: () => {
       confirmAlert("success", "등록이 완료되었습니다.");
-      navigate('/admin/gallery');
+      navigate("/gallery");
+      queryClient.invalidateQueries({ queryKey: ["adminGallery"] });
     },
     onError: (e) => {
       console.log(e, "error");


### PR DESCRIPTION
### #️⃣연관된 이슈
- ex) #이슈번호, #이슈번호
- close #138 

### 📝작업 내용
- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 관리자 포스트 페이지에 카테고리별 등록버튼 추가
- 첨부파일 다운로드 a태그 변경
- 페이지에서 데이터 0일때 에러핸들링 추가 
- 관리자 유저페이지 남녀성별 수정

### 스크린샷 (선택)
![스크린샷 2024-07-22 173101](https://github.com/user-attachments/assets/fa2b25e7-5229-42ec-8417-518586fc0d67)


### 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
