### PR TITLE
포스트 등록 및 수정 페이지 개선

### DIFF
--- a/src/features/ckEditor/ui/CkEditor.tsx
+++ b/src/features/ckEditor/ui/CkEditor.tsx
@@ -5,11 +5,14 @@ import Editor from "ckeditor5-custom-build/build/ckeditor";
 import { CKEditor } from "@ckeditor/ckeditor5-react";
 import React from "react";
 import { Api } from "../../../shared/api";
-import {ClassicEditor} from "@ckeditor/ckeditor5-editor-classic";
 
+export type ckEditorResponse= {
+  fileUrl:string
+  fileName:string
+}
 type Props = {
   setCkData: React.Dispatch<any>;
-  setNewCkImgUrls: React.Dispatch<React.SetStateAction<string[]>>;
+  setNewCkImgUrls: React.Dispatch<React.SetStateAction<ckEditorResponse[]>>;
   ckData: string;
 };
 
@@ -83,7 +86,7 @@ export const CkEditor = ({ ckData, setCkData, setNewCkImgUrls }: Props) => {
             })
               .then((res) => {
                 setNewCkImgUrls((prevState) => {
-                  return [...prevState, res.data.url];
+                  return [...prevState, {fileUrl:res.data.url, fileName:res.data.fileName}];
                 });
                 resolve({
                   default: res.data.url,

--- a/src/pages/competitionPage/ui/PostCompetitionPage.tsx
+++ b/src/pages/competitionPage/ui/PostCompetitionPage.tsx
@@ -14,6 +14,7 @@ import FetchPostCompetition from "../api/FetchPostCompetition";
 import {useNavigate} from "react-router-dom";
 import {useQuery} from "@tanstack/react-query";
 import FetchGetDivisionList from "../api/FetchGetDivisionList";
+import {ckEditorResponse} from "../../../features/ckEditor/ui/CkEditor";
 
 
 
@@ -27,7 +28,7 @@ export const PostCompetitionPage = () => {
     const [relatedURL, setRelatedUrl] = useState<string | null>(null);
     const [files, setFiles] = useState<IFileTypes[]>([]);
     const [ckData, setCkData] = useState<string>("");
-    const [newCkImgUrls, setNewCkImgUrls] = useState<string[]>([]);
+    const [newCkImgUrls, setNewCkImgUrls] = useState<ckEditorResponse[]>([]);
     const navigate = useNavigate();
     const [divisionList, setDivisionList] = useState<divisionType[]>([])
 
@@ -62,12 +63,12 @@ export const PostCompetitionPage = () => {
             places: places,
             relatedURL: relatedURL,
             ckData:ckData,
-            realCkImgs:[]
+            ckImgRequests:[]
         }
 
         for (let i:number = 0; i < newCkImgUrls.length; i++) {
-            if(ckData.includes(newCkImgUrls[i])) {
-                requestData.realCkImgs.push(newCkImgUrls[i])
+            if(ckData.includes(newCkImgUrls[i].fileUrl)) {
+                requestData.ckImgRequests.push(newCkImgUrls[i])
             }
         }
         confirmAndCancelAlertWithLoading("question", "대회를 등록하시겠습니까?", "", async () => {

--- a/src/pages/competitionPage/ui/UpdateCompetitionPage.tsx
+++ b/src/pages/competitionPage/ui/UpdateCompetitionPage.tsx
@@ -25,6 +25,7 @@ import {useQuery} from "@tanstack/react-query";
 import FetchCompetitionInfo from "../../../widgets/competition/api/FetchCompetitionInfo";
 import {useNavigate, useParams} from "react-router-dom";
 import FetchGetDivisionList from "../api/FetchGetDivisionList";
+import {ckEditorResponse} from "../../../features/ckEditor/ui/CkEditor";
 
 
 
@@ -39,7 +40,7 @@ export const UpdateCompetitionPage = () => {
     const [files, setFiles] = useState<IFileTypes[]>([]);
     const [ckData, setCkData] = useState<string>("");
     const [attachedFileList, setAttachedFileList] = useState<competitionDetailAttachedFile[]>([])
-    const [newCkImgUrls, setNewCkImgUrls] = useState<string[]>([]);
+    const [newCkImgUrls, setNewCkImgUrls] = useState<ckEditorResponse[]>([]);
     const navigate = useNavigate();
     const [divisionList, setDivisionList] = useState<divisionType[]>([]);
 
@@ -83,7 +84,7 @@ export const UpdateCompetitionPage = () => {
             updatePlaces: places,
             relatedURL: relatedURL,
             ckData:ckData,
-            realCkImgs:[],
+            ckImgRequests:[],
             uploadedAttachedFiles:attachedFileList.map((item) => item.filePath),
             deletedCkImgUrls: []
         }
@@ -96,8 +97,8 @@ export const UpdateCompetitionPage = () => {
         }
         // 새로운 ck 이미지
         for (let i:number = 0; i < newCkImgUrls.length; i++) {
-            if(ckData.includes(newCkImgUrls[i])) {
-                requestData.realCkImgs.push(newCkImgUrls[i])
+            if(ckData.includes(newCkImgUrls[i].fileUrl)) {
+                requestData.ckImgRequests.push(newCkImgUrls[i])
             }
         }
         confirmAndCancelAlertWithLoading("question", "대회를 수정하시겠습니까?", "", async () => {

--- a/src/pages/postPage/api/AddPostRequest.ts
+++ b/src/pages/postPage/api/AddPostRequest.ts
@@ -1,13 +1,10 @@
 import { Api } from "shared/api";
-import { PostImgsType } from "shared/type/PostType";
+import {RemainingFilesType} from "shared/type/PostType";
 
 export interface requestPostData {
   title: string;
   content: string;
-  postImgs: {
-    fileName:string,
-    fileUrl: string,
-  }[];
+  postImgs: RemainingFilesType[];
 }
 
 const AddPostRequest = (params: {

--- a/src/pages/postPage/api/AddPostRequest.ts
+++ b/src/pages/postPage/api/AddPostRequest.ts
@@ -11,7 +11,7 @@ const AddPostRequest = (params: {
   category?: string;
   data: requestPostData;
   OfficialState: "official" | "normal";
-  postFiles: FileList | null;
+  postFiles: File[];
 }) => {
   const { category, data, OfficialState, postFiles } = params;
   const officialBoolean = OfficialState === "official";

--- a/src/pages/postPage/api/EditPostRequest.ts
+++ b/src/pages/postPage/api/EditPostRequest.ts
@@ -13,7 +13,7 @@ const EditPostRequest = (params: {
   requestData: EditRequestPostData;
   postId?: string;
   officialState: "official" | "normal";
-  uploadFiles: FileList | null;
+  uploadFiles: File[];
 }) => {
   const { category, requestData, postId, officialState, uploadFiles } = params;
   const officialBoolean = officialState === "official";

--- a/src/pages/postPage/api/MutationEditPost.ts
+++ b/src/pages/postPage/api/MutationEditPost.ts
@@ -1,0 +1,34 @@
+import {QueryClient, useMutation} from "@tanstack/react-query";
+import EditPostRequest from "./EditPostRequest";
+import confirmAlert from "../../../shared/lib/alert/ConfirmAlert";
+import axios from "axios";
+
+
+export default function MutationEditPost(queryClient:QueryClient, category:string | undefined) {
+    return  useMutation({
+        mutationFn: EditPostRequest,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["postList"] });
+            confirmAlert("success", "수정 성공", "게시글 수정을 완료하였습니다.")
+                .then(res => {
+                    if (res.isConfirmed) window.location.href = `/post/${category}`;
+                })
+        },
+        onError: (e) => {
+            if (axios.isAxiosError(e)) {
+                if (e.response?.status === 409) {
+                    confirmAlert("warning", "중복된 게시글 제목입니다.");
+                }
+                if (e.response?.status === 403) {
+                    confirmAlert("warning", "게시글 작성 권한이 없습니다.");
+                }
+                if (e.response?.status === 400) {
+                    confirmAlert("warning", "게시글 제목 또는 내용을 입력해주세요.");
+                }
+                if (e.response?.status === 404) {
+                    confirmAlert("warning", "존재하지 않는 작성자입니다.");
+                }
+            }
+        },
+    });
+}

--- a/src/pages/postPage/ui/AddPostPage.module.css
+++ b/src/pages/postPage/ui/AddPostPage.module.css
@@ -130,24 +130,78 @@
 .buttonCancel:hover {
   background-color: var(--subcolor-black4);
 }
-.uploadFile {
-  width: 250px;
-  border: none;
-}
+/*.uploadFile {*/
+/*  width: 250px;*/
+/*  border: none;*/
+/*}*/
 
-.uploadFileWrapper {
+/*.uploadFileWrapper {*/
+/*  display: flex;*/
+/*}*/
+
+/*.uploadFileTitle {*/
+/*  margin-right: 20px;*/
+/*}*/
+/*.uploadFileBundle{*/
+/*  display: flex;*/
+/*  flex-direction: column;*/
+/*  gap: 5px;*/
+/*}*/
+
+/*.uploadFileItem{*/
+/*  text-decoration: underline;*/
+/*}*/
+
+.inputWrapper {
   display: flex;
 }
 
-.uploadFileTitle {
-  margin-right: 20px;
+.customFileInput {
+  position: relative;
+  display: inline-block;
+  width: 100px;
+  height: 40px;
+  overflow: hidden;
+  cursor: pointer;
+  text-align: center;
+  line-height: 40px;
+  border-radius: 4px;
+  background-color: var(--primary-color);
 }
-.uploadFileBundle{
+
+.customFileInput:hover {
+  color: white;
+}
+
+.customFileInput input[type="file"] {
+  cursor: pointer;
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.fileBundleWrapper {
   display: flex;
   flex-direction: column;
   gap: 5px;
+  margin-left: 17px;
 }
 
-.uploadFileItem{
-  text-decoration: underline;
+.deleteButton {
+  border: none;
+  color: #fff;
+  width: 15px;
+  height: 100%;
+  margin-left: 7px;
+  background-repeat: no-repeat;
+  background-position: center;
+
+  background-image: url(/public/icon/delete.svg);
+}
+
+.fileItemWrapper {
+  display: flex;
 }

--- a/src/pages/postPage/ui/AddPostPage.tsx
+++ b/src/pages/postPage/ui/AddPostPage.tsx
@@ -6,11 +6,12 @@ import OfficialOptions from "../../../shared/model/officialOptions";
 import Select, { SingleValue } from "react-select";
 import { useMutation } from "@tanstack/react-query";
 import AddPostRequest, { requestPostData } from "../api/AddPostRequest";
-import { PostImgsType } from "shared/type/PostType";
+import {PostImgsType, RemainingFilesType} from "shared/type/PostType";
 import styles from "./AddPostPage.module.css";
 import { PageTitle } from "../../../shared/ui";
 import axios from "axios";
 import confirmAlert from "shared/lib/alert/ConfirmAlert";
+import {ckEditorResponse} from "../../../features/ckEditor/ui/CkEditor";
 
 const customStyles = {
   control: (provided: any) => ({
@@ -31,14 +32,13 @@ export const AddPostPage = () => {
   const [OfficialState, setOfficialState] = useState<"official" | "normal">(
     "normal"
   );
-  const [postImgs, setPostImgs] = useState<PostImgsType[]>([]);
-  const [postFiles, setPostFiles] = useState<FileList | null>(null);
-  const [newCkImgUrls, setNewCkImgUrls] = useState<string[]>([]);
-  const [fileName, setFileName] = useState<string[]>([]);
+  const [postFiles, setPostFiles] = useState<File[]>([]);
+  const [newCkImgUrls, setNewCkImgUrls] = useState<ckEditorResponse[]>([]);
+  // const [fileName, setFileName] = useState<string[]>([]);
 
   const navigate = useNavigate();
   let { category } = useParams();
-  const inputRef = useRef<HTMLInputElement>(null);
+  // const inputRef = useRef<HTMLInputElement>(null);
   const detailTitle =
     category === "notice"
       ? "공지사항"
@@ -49,12 +49,10 @@ export const AddPostPage = () => {
   const mutation = useMutation({
     mutationFn: AddPostRequest,
     onSuccess: () => {
-      navigate(`/post/${category}`);
-      confirmAlert(
-        "success",
-        "작성 완료",
-        "게시글 작성을 성공적으로 완료하였습니다."
-      );
+      confirmAlert("success", "작성 완료", "게시글 작성을 성공적으로 완료하였습니다.")
+          .then(res => {
+            if (res.isConfirmed) navigate(`/post/${category}`);
+          });
     },
     onError: (e) => {
       if (axios.isAxiosError(e)) {
@@ -78,7 +76,7 @@ export const AddPostPage = () => {
     category?: string;
     data: requestPostData;
     OfficialState: "official" | "normal";
-    postFiles: FileList | null;
+    postFiles: File[];
   }) => {
     mutation.mutate(params);
   };
@@ -87,8 +85,8 @@ export const AddPostPage = () => {
     event.preventDefault();
     const ckImgs:{fileName:string, fileUrl:string}[] = newCkImgUrls.map((item) => {
       return {
-        fileName: item,
-        fileUrl: item
+        fileName: item.fileName,
+        fileUrl: item.fileUrl
       }
     })
     const requestData: requestPostData = {
@@ -105,20 +103,39 @@ export const AddPostPage = () => {
 
   };
 
+  const handleUploadFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      setPostFiles(prevState => {
+        let result = [...prevState]
+        for (let i: number = 0; i < files.length; i++) {
+          const file = files.item(i)
+          if (file) result.push(file)
+        }
+        return result
+      });
+    }
+  }
+
+  // 추가된 파일 삭제 로직
+  const handleDeleteUploadFiles = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>,indexToRemove:number) => {
+    e.preventDefault()
+    setPostFiles(prev => prev.filter((f, index) => index !== indexToRemove))
+  }
 
   const officialOptionHandler = (selectedOption: SingleValue<any>): void => {
     setOfficialState(selectedOption.value);
   };
 
 
-  useEffect(() => {
-    if (inputRef.current?.files) {
-      const files = inputRef.current?.files;
-      for (let i = 0; i < files.length; i++) {
-        setFileName((prev) => [...prev, files[i].name]);
-      }
-    }
-  }, [postFiles]);
+  // useEffect(() => {
+  //   if (inputRef.current?.files) {
+  //     const files = inputRef.current?.files;
+  //     for (let i = 0; i < files.length; i++) {
+  //       setFileName((prev) => [...prev, files[i].name]);
+  //     }
+  //   }
+  // }, [postFiles]);
 
   return (
     <div className={styles.container}>
@@ -161,26 +178,52 @@ export const AddPostPage = () => {
             </div>
             <div className={styles.filesWrapper}>
               <div className={styles.subLine}></div>
-              <div className={styles.uploadFileWrapper}>
-                <span className={styles.uploadFileTitle}>첨부파일</span>
-                <div className={styles.uploadFileBundle}>
-                  {!!fileName.length ? (
-                    fileName.map((item, i) => (
-                      <div className={styles.uploadFileItem} key={i}>
-                        {item}
-                      </div>
-                    ))
-                  ) : (
-                    <input
-                      ref={inputRef}
-                      className={styles.uploadFile}
+              {/*<div className={styles.uploadFileWrapper}>*/}
+              {/*  <span className={styles.uploadFileTitle}>첨부파일</span>*/}
+              {/*<div className={styles.uploadFileBundle}>*/}
+              {/*  {!!fileName.length ? (*/}
+              {/*    fileName.map((item, i) => (*/}
+              {/*      <div className={styles.uploadFileItem} key={i}>*/}
+              {/*        {item}*/}
+              {/*      </div>*/}
+              {/*    ))*/}
+              {/*  ) : (*/}
+              {/*    <input*/}
+              {/*      ref={inputRef}*/}
+              {/*      className={styles.uploadFile}*/}
+              {/*      type="file"*/}
+              {/*      name="uploadFile"*/}
+              {/*      id="uploadFile"*/}
+              {/*      multiple*/}
+              {/*      onChange={(e) => setPostFiles(e.target.files)}*/}
+              {/*    />*/}
+              {/*  )}*/}
+              {/*</div>*/}
+              {/*</div>*/}
+              <div className={styles.inputWrapper}>
+                <div className={styles.customFileInput}>
+                  <p>파일선택</p>
+                  <input
                       type="file"
-                      name="uploadFile"
                       id="uploadFile"
                       multiple
-                      onChange={(e) => setPostFiles(e.target.files)}
-                    />
-                  )}
+                      onChange={(e) => handleUploadFiles(e)}
+                  />
+                </div>
+                <div className={styles.fileBundleWrapper}>
+                  {postFiles.map((file: File, index: number) => (
+                      <div key={index} className={styles.fileItemWrapper}>
+                      <span>
+                        {file.name}
+                      </span>
+                        <button
+                            onClick={(e) =>
+                                handleDeleteUploadFiles(e, index)
+                            }
+                            className={styles.deleteButton}
+                        />
+                      </div>
+                  ))}
                 </div>
               </div>
               <div className={styles.subLine}></div>
@@ -189,9 +232,9 @@ export const AddPostPage = () => {
               <div className={styles.buttonWrapper}>
                 <Button type="submit">작성 완료</Button>
                 <Button
-                  className={styles.buttonCancel}
-                  type="button"
-                  onClick={() => navigate(`/post/${category}`)}
+                    className={styles.buttonCancel}
+                    type="button"
+                    onClick={() => navigate(`/post/${category}`)}
                 >
                   취소
                 </Button>

--- a/src/pages/postPage/ui/PostDetailPage.module.css
+++ b/src/pages/postPage/ui/PostDetailPage.module.css
@@ -96,6 +96,7 @@
   display: flex;
   margin: 10px;
   flex-direction: column;
+  align-items: flex-start;
 }
 .fileNull {
   padding-left: 16px;

--- a/src/pages/postPage/ui/PostDetailPage.tsx
+++ b/src/pages/postPage/ui/PostDetailPage.tsx
@@ -11,6 +11,8 @@ import { LoadingSpinner, PageTitle } from "shared/ui";
 import axios from "axios";
 import confirmAlert from "shared/lib/alert/ConfirmAlert";
 import confirmDelete from "shared/lib/alert/ConfirmDelete";
+import {FilesType} from "../../../shared/type/PostType";
+import {handleDownload} from "../../../shared/lib/handleDownload";
 
 export const PostDetailPage = () => {
   let { postId, category } = useParams();
@@ -133,14 +135,15 @@ export const PostDetailPage = () => {
                 {
                   postDetail?.files.length > 0
                       ?
-                      postDetail?.files?.map((item: { fileId: number; fileName: string; fileUrl: string }) => (
-                          <a
+                      postDetail?.files?.map((item:FilesType, i:number) => (
+                          <button
+                              // download 속성을 넣어도 원본 파일명이 다운로드 되서 fetch 로직으로 변경했어요.
+                              onClick={() => handleDownload(item.fileUrl, item.fileName)}
                               key={item.fileId}
-                              href={item.fileUrl}
                               className={styles.fileDownloadItem}
                           >
                             {item.fileName}
-                          </a>
+                          </button>
                       ))
                       :
                       <span className={styles.fileNull}>첨부파일 없음</span>

--- a/src/pages/postPage/ui/UpdatePostPage.module.css
+++ b/src/pages/postPage/ui/UpdatePostPage.module.css
@@ -147,13 +147,39 @@
 }
 
 .uploadFile {
-  width: 160px;
-  border: none;
+  /*width: 160px;*/
+  /*border: none;*/
+}
+
+.customFileInput {
+  position: relative;
+  display: inline-block;
+  width: 100px;
+  height: 40px;
+  overflow: hidden;
+  cursor: pointer;
+  text-align: center;
+  line-height: 40px;
+  border-radius: 4px;
+  background-color: var(--primary-color);
+}
+
+.customFileInput:hover {
+  color: white;
+}
+
+.customFileInput input[type="file"] {
+  cursor: pointer;
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .fileItemWrapper {
   display: flex;
-  align-items: center;
 }
 .fileBundleWrapper {
   display: flex;

--- a/src/pages/postPage/ui/UpdatePostPage.tsx
+++ b/src/pages/postPage/ui/UpdatePostPage.tsx
@@ -74,6 +74,7 @@ export const UpdatePostPage = () => {
     enabled: !!postId, // postId가 존재할 때에만 호출
     select: (result: any) => result.data.data,
   });
+  console.log(postDetail)
 
   const queryClient = useQueryClient();
 
@@ -115,14 +116,14 @@ export const UpdatePostPage = () => {
   const formSubmitHandler = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const remainingFiles: RemainingFilesType[] = [];
-    const postImgs: {fileName:string, fileUrl:string}[] = [];
+    let postImgs: {fileName:string, fileUrl:string}[] = [];
     remainingFilesState.map(
       (item) =>
         item.fileUrl &&
         remainingFiles.push({ fileName: item.fileName, fileUrl: item.fileUrl })
     );
     postImgsState.forEach((item) =>
-      postImgs.push({ fileName: item.fileName, fileUrl: item.fileUrl })
+      postImgs.push(item)
     );
     newCkImgUrls.forEach((item) => {
       postImgs.push({fileName: item, fileUrl:item})
@@ -226,7 +227,7 @@ export const UpdatePostPage = () => {
   useEffect(() => {
     if (postDetail) {
       const imgList = postDetail.postImgs.map(item => {
-        return {fileName:item.fileName, fileUrl:item.imgUrl}
+        return {fileName:item.fileName, fileUrl:item.fileUrl}
       })
       setTitle(postDetail.title);
       setContent(postDetail.content);

--- a/src/shared/lib/handleDownload.ts
+++ b/src/shared/lib/handleDownload.ts
@@ -1,0 +1,12 @@
+export const handleDownload = async (fileUrl:string, name:string) => {
+    const response = await fetch(fileUrl);
+    const blob = await response.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = name; // 여기서 원하는 파일 이름을 지정합니다.
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+};

--- a/src/shared/type/CompetitionType.ts
+++ b/src/shared/type/CompetitionType.ts
@@ -1,3 +1,5 @@
+import {ckEditorResponse} from "../../features/ckEditor/ui/CkEditor";
+
 export type requestData = {
     title: string;
     divisions: string[];
@@ -6,7 +8,7 @@ export type requestData = {
     places: place[];
     relatedURL: string | null;
     ckData:any;
-    realCkImgs:string[];
+    ckImgRequests:ckEditorResponse[];
 }
 
 export type IFileTypes = {
@@ -22,7 +24,7 @@ export type updateRequestData = {
     updatePlaces: place[];
     relatedURL: string | null;
     ckData:any;
-    realCkImgs:string[];
+    ckImgRequests:ckEditorResponse[];
     uploadedAttachedFiles:string[];
     deletedCkImgUrls: string[]
 }

--- a/src/shared/type/PostType.ts
+++ b/src/shared/type/PostType.ts
@@ -49,6 +49,6 @@ export interface PostDetailType {
   createAt: string;
   viewCount: number;
   files: any[]; // files가 배열인데 정확한 구조를 알 수 없으므로 any[]로 정의
-  postImgs: PostImgsType[];
+  postImgs: FilesType[];
   content: string;
 }

--- a/src/widgets/competition/ui/CompetitionDetailInfo.tsx
+++ b/src/widgets/competition/ui/CompetitionDetailInfo.tsx
@@ -9,6 +9,7 @@ import {useNavigate, useParams} from "react-router-dom";
 import {useUserStore} from "../../../shared/model";
 import FetchDeleteCompetition from "../api/FetchDeleteCompetition";
 import confirmAndCancelAlertWithLoading from "../../../shared/lib/alert/ConfirmAndCancelAlertWithLoading";
+import {handleDownload} from "../../../shared/lib/handleDownload";
 
 type Props = {
     data:competitionDetailData
@@ -82,7 +83,7 @@ export const CompetitionDetailInfo = ({data}:Props) => {
                     <CompetitionDetailLabel name={"첨부파일"}/>
                     <div
                         className={style.info}>{data?.competitionDetailAttachedFiles.map((f: competitionDetailAttachedFile, index: number) => {
-                        return <a href={f.filePath} key={index}>{index + 1}. {f.fileName}</a>
+                        return <button onClick={() => handleDownload(f.filePath, f.fileName)} key={f.competitionAttachedFileId}>{index + 1}. {f.fileName}</button>
                     })}</div>
                 </div>
             </div>

--- a/src/widgets/competition/ui/ResultRow.tsx
+++ b/src/widgets/competition/ui/ResultRow.tsx
@@ -4,6 +4,7 @@ import {getCompetitionResultRow} from "../../../shared/type/CompetitionType";
 import formatDate from "../../../shared/lib/formatDate";
 import {MdOutlineDriveFolderUpload} from "react-icons/md";
 import confirmAlert from "../../../shared/lib/alert/ConfirmAlert";
+import {handleDownload} from "../../../shared/lib/handleDownload";
 
 
 type Props = {
@@ -14,12 +15,7 @@ export const ResultRow = ({data}:Props) => {
 
     function fileHandler() {
         if(data.filePath) {
-            const a = document.createElement('a');
-            a.href = data.filePath;
-            a.download = data.fileName;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
+            handleDownload(data.filePath, data.fileName)
         }else {
             confirmAlert("warning", "파일이 없습니다.")
         }
@@ -59,10 +55,10 @@ export const ResultRow = ({data}:Props) => {
                 </div>
             </div>
             <div className={style.fileArea}>
-                <a className={style.fileBtn} onClick={fileHandler}>
+                <button className={style.fileBtn} onClick={fileHandler}>
                     <MdOutlineDriveFolderUpload size={24}/>
                     <p>파일</p>
-                </a>
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
### #️⃣연관된 이슈
- ex) #이슈번호, #이슈번호

### 📝작업 내용
- 게시물 업데이트 버그 수정(백엔드에서 주고받는 변수이름 문제였음 -> "fileUrl" VS "imgUrl")
- 게시물 작성 시 첨부파일 하나씩 업로드 못하는 기능 개선(첨부파일 등록 로직 수정)
- 첨부파일 버튼 스타일 변경
- 게시물 등록 시 첨부파일 한번 등록하면 재등록 못하는 기능 개선
- CkEditor 이미지 업로드 후 백엔드로 파일name 안주고 있었는데 하는김에 수정(이제 각 img 테이블에 fileName 정상적으로 등록됨)
- 첨부파일 다운로드 시 fileName 으로 다운로드 안되는 현상 수정
- 기타 오류 수정

### 스크린샷 (선택)


### 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
